### PR TITLE
Use fixed go version, not unreliable master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - master
+  - 1.12.x
 
 sudo: false
 


### PR DESCRIPTION
version 1.12.x should be okay to use without errors