### PR TITLE
Update bug tracker link to github issues

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -86,7 +86,7 @@ googleAnalytics = ""
 
 [[menu.main]]
     name = "Bugs"
-    url = "https://bugs.vcmi.eu/"
+    url = "https://github.com/vcmi/vcmi/issues"
     identifier = "fa fa-bug"
     weight = 40
 

--- a/content/faq.md
+++ b/content/faq.md
@@ -32,7 +32,7 @@ title = "Frequently Asked Questions (FAQ)"
 
 * Where do I report bugs?
 
-> Report bugs on <https://bugs.vcmi.eu/my_view_page.php>, we strongly recommend using english language.
+> Report bugs on <https://github.com/vcmi/vcmi/issues>, we strongly recommend using english language.
 
 * How do I contact you?
 


### PR DESCRIPTION
We're using github for tracking bugs so the site should reflect that too.