### PR TITLE
new pillow (support python 3.13)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ mkdocs-rss-plugin==1.12.2
 mdutils==1.6.0
 json_repair==0.20.1
 json5==0.9.25
-pillow==10.3.0
+pillow==11.1.0
 numpy==1.26.4
 homm3data==0.1.5


### PR DESCRIPTION
another case of GitHub is updating images and breaking scripts...

Python 3.12 -> Python 3.13

https://github.com/actions/runner-images/commit/3ea8ee216fa3eb4573a432663ddbd405cdb9d6a9

@dydzio0614 